### PR TITLE
Support PORT from environment variable

### DIFF
--- a/middleware/httpserver/http_server.go
+++ b/middleware/httpserver/http_server.go
@@ -1,8 +1,10 @@
 package httpserver
 
 import (
+	"fmt"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/mtojek/greenwall/middleware/application"
 	"github.com/mtojek/greenwall/middleware/healthcheck"
@@ -29,7 +31,15 @@ func NewHTTPServer(applicationConfiguration *application.Configuration,
 
 // ListenAndServe method listens and serves requests sent to HTTP handlers.
 func (httpServer *HTTPServer) ListenAndServe() {
-	err := http.ListenAndServe(httpServer.applicationConfiguration.HostPort, httpServer.serverMux)
+	serverPort := os.Getenv("PORT")
+	addr := ":" + serverPort
+
+	if len(serverPort) == 0 {
+		addr = httpServer.applicationConfiguration.HostPort
+	}
+
+	fmt.Printf("Start listening on %s\n", addr)
+	err := http.ListenAndServe(addr, httpServer.serverMux)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
#### Why
As of now there is no way to specify port using environment variable , which is used for most of cloud platform , eg heroku , cloudfoundry.

#### Changes
- Provision to use PORT from environment variable.
- Add UI message for server start along with PORT in use 