### PR TITLE
Support HTTP health check with Basic Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ groups:
         type: http_check
         parameters:
             expectedPattern: Example
+            basicAuthUsername: username
+            basicAuthPassword: password
       - name: front-2
         endpoint: https://www.example.com/
         type: http_check

--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,8 @@ groups:
         type: http_check
         parameters:
           expectedPattern: Example
+          basicAuthUsername: username
+          basicAuthPassword: password
       - name: front-2a (deprecated)
         endpoint: https://www.example.com/
         expectedPattern: Example


### PR DESCRIPTION
Hi 

I required HTTP health check with Basic Authentication, so this PR is for that features.

* add `basicAuthUsername` parameter
* add `basicAuthPassword` parameter
* If both parameters specified, GET request with authentication

Then, greenwall is so cool!